### PR TITLE
An addition of a `vec_bsearch` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ vector remains unchanged.
 Sorts the values of the vector; `fn` should be a qsort-compatible compare
 function.
 
+### vec\_bsearch(v, key, idx, fn)
+Performs a binary search for `key` on the vector; the elements must be in sorted 
+order according to the qsort-compatible function `fn`. The value pointed to by
+`idx` is filled with index of `key` if found, -1 if not found.
+
 ### vec\_swap(v, idx1, idx2)
 Swaps the values at the indices `idx1` and `idx2` with one another.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ function.
 Performs a binary search for `key` on the vector; the elements must be in sorted 
 order according to the qsort-compatible function `fn`. The value pointed to by
 `idx` is filled with index of `key` if found, -1 if not found.
+```c
+/* Searches the vector for the key 4*/
+int key = 4;
+int idx = -1;
+vec_bsearch(&v, &key, &idx, compareIntegers);
+/* idx != -1 if key was found... */
+```
 
 ### vec\_swap(v, idx1, idx2)
 Swaps the values at the indices `idx1` and `idx2` with one another.

--- a/src/vec.h
+++ b/src/vec.h
@@ -59,6 +59,14 @@
   qsort((v)->data, (v)->length, sizeof(*(v)->data), fn)
 
 
+#define vec_bsearch(v, key, idx, fn) \
+  do {\
+    char* ptr = NULL; \
+    ptr = bsearch(key, (v)->data, (v)->length, sizeof(*(v)->data), fn); \
+    *idx = ptr ? (ptr - (char*)(v)->data) / sizeof(*(v)->data) : -1; \
+  } while (0)
+
+
 #define vec_swap(v, idx1, idx2)\
   vec_swap_(vec_unpack_(v), idx1, idx2)
 

--- a/test/test_vec.c
+++ b/test/test_vec.c
@@ -119,6 +119,28 @@ int main(void) {
     vec_deinit(&v);
   }
 
+  { test_section("vec_bsearch");
+    vec_int_t v;
+    vec_init(&v);
+    vec_push(&v, 0);
+    vec_push(&v, 1);
+    vec_push(&v, 4);
+    vec_push(&v, 14);
+    vec_push(&v, 30);
+    vec_push(&v, 35);
+	int key = 4;
+	int idx = -1;
+    vec_bsearch(&v, &key, &idx, intptrcmp);
+    test_assert(idx == 2);
+	key = 30;
+	vec_bsearch(&v, &key, &idx, intptrcmp);
+    test_assert(idx == 4);
+	key = 40;
+	vec_bsearch(&v, &key, &idx, intptrcmp);
+    test_assert(idx == -1);
+    vec_deinit(&v);
+  }
+
   { test_section("vec_swap");
     vec_int_t v;
     vec_init(&v);


### PR DESCRIPTION
I would like to add a method to perform a binary search on the vec.
My rationale is that currently there are no operations available on the vector in sorted form (withing diving into struct data), although it can be sorted. Instead of always performing a linear search, bsearch may be more appropriate. This also completes an encapsulation of the two algorithmic functions (qsort, bsearch) of C with the vec interface.

I have kept the implementation in a type-safe manner by making the return value `idx` passed to the function. However, I am unsure about possible pitfalls of the subtraction of two pointers  in the implementation, although both are cast to char*.
